### PR TITLE
small fix, double line in .dstyle file.

### DIFF
--- a/darktable_style/fujicolor-print-industrial-100-dehancer-colorchecker.dtstyle
+++ b/darktable_style/fujicolor-print-industrial-100-dehancer-colorchecker.dtstyle
@@ -6,7 +6,6 @@
 </info>
 <style>
   <plugin>
-  <plugin>
     <num>0</num>
     <module>2</module>
     <operation>colorchecker</operation>


### PR DESCRIPTION
fujicolor print industrial dstyle was not being imported to darktable. now fixed.